### PR TITLE
Create C library for token issuer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 dist
 src/*.egg-info
+src/*.pyc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,49 @@
+####
+#
+# Simple C library for fetching an access token
+# utilizing an OAuth2 client credential workflow.
+#
+# Internally, this uses an embedded python interpreter
+# to do all the heavy lifting.
+#
+###
+
+cmake_minimum_required( VERSION 2.8 )
+project( x509-scitokens-issuer )
+
+find_package( Boost REQUIRED COMPONENTS python )
+find_package( PythonLibs REQUIRED )
+find_package( PythonInterp REQUIRED )
+
+macro(use_cxx11)
+  if (CMAKE_VERSION VERSION_LESS "3.1")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      set (CMAKE_CXX_FLAGS "-std=gnu++11 ${CMAKE_CXX_FLAGS}")
+    endif ()
+  else ()
+    set (CMAKE_CXX_STANDARD 11)
+  endif ()
+endmacro(use_cxx11)
+use_cxx11()
+
+if( CMAKE_COMPILER_IS_GNUCXX )
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror" )
+endif()
+SET( CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined")
+SET( CMAKE_MODULE_LINKER_FLAGS "-Wl,--no-undefined")
+
+include_directories(${PYTHON_INCLUDE_DIRS} ${BOOST_INCLUDE_DIRS})
+
+add_library(X509SciTokensIssuer SHARED src/x509_scitokens_issuer.cpp)
+target_link_libraries(X509SciTokensIssuer -ldl ${Boost_PYTHON_LIBRARY} ${PYTHON_LIBRARIES})
+set_target_properties(X509SciTokensIssuer PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols")
+
+SET(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Install path for libraries")
+
+install(
+  TARGETS X509SciTokensIssuer
+  LIBRARY DESTINATION ${LIB_INSTALL_DIR})
+
+install(
+  FILES ${CMAKE_SOURCE_DIR}/src/x509_scitokens_issuer_client.py
+  DESTINATION ${LIB_INSTALL_DIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/ )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,11 +38,18 @@ add_library(X509SciTokensIssuer SHARED src/x509_scitokens_issuer.cpp)
 target_link_libraries(X509SciTokensIssuer -ldl ${Boost_PYTHON_LIBRARY} ${PYTHON_LIBRARIES})
 set_target_properties(X509SciTokensIssuer PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols")
 
+add_executable(cms-scitokens-init tools/cms-scitoken-init.cpp)
+target_link_libraries(cms-scitokens-init -ldl)
+
 SET(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Install path for libraries")
 
 install(
   TARGETS X509SciTokensIssuer
   LIBRARY DESTINATION ${LIB_INSTALL_DIR})
+
+install(
+  TARGETS cms-scitokens-init
+  DESTINATION bin)
 
 install(
   FILES ${CMAKE_SOURCE_DIR}/src/x509_scitokens_issuer_client.py

--- a/configs/export-lib-symbols
+++ b/configs/export-lib-symbols
@@ -1,0 +1,7 @@
+{
+global:
+  x509_scitokens_issuer*;
+
+local:
+  *;
+};

--- a/src/x509_scitokens_issuer.cpp
+++ b/src/x509_scitokens_issuer.cpp
@@ -1,0 +1,82 @@
+
+#include <boost/python.hpp>
+
+#include <mutex>
+#include <string>
+
+#include <dlfcn.h>
+#include <string.h>
+
+static bool g_initialized = false;
+static std::mutex g_mutex;
+static boost::python::object g_module;
+
+
+extern"C" bool
+x509_scitokens_issuer_init()
+{
+    std::lock_guard<std::mutex> guard(g_mutex);
+    if (g_initialized) {return true;}
+
+    if (!Py_IsInitialized())
+    {
+        char pname[] = "x509_scitokens_issuer";
+        Py_SetProgramName(pname);
+        Py_InitializeEx(0);
+    }
+
+    // We need to reload the current shared library:
+    //   - RTLD_GLOBAL instructs the loader to put everything into the global symbol
+    //     table. Python requires this for several modules.
+    //   - RTLD_NOLOAD instructs the loader to actually reload instead of doing an
+    //     initial load.
+    //   - RTLD_NODELETE instructs the loader to not unload this library -- we need
+    //     python kept in memory!
+    void *handle = dlopen("libX509SciTokensIssuer.so", RTLD_GLOBAL|RTLD_NODELETE|RTLD_NOLOAD|RTLD_LAZY);
+    if (handle == nullptr)
+    {
+        return false;
+    }
+    dlclose(handle);
+
+    try
+    {
+        g_module = boost::python::import("x509_scitokens_issuer_client");
+    }
+    catch (boost::python::error_already_set)
+    {
+        return false;
+    }
+    return true;
+}
+
+
+extern "C" char *
+x509_scitokens_issuer_retrieve(const char *issuer, const char *cert, const char *key)
+{
+    if (!issuer) {return nullptr;}
+    std::lock_guard<std::mutex> guard(g_mutex);
+
+    boost::python::object py_cert;
+    if (cert) {
+        py_cert = boost::python::object(cert);
+    }
+    boost::python::object py_key;
+    if (key) {
+        py_key = boost::python::object(key);
+    }
+    boost::python::object py_issuer = boost::python::object(issuer);
+
+    std::string token;
+    try
+    {
+        boost::python::object retval =
+            g_module.attr("get_token")(py_issuer, py_cert, py_key)["access_token"];
+        token = boost::python::extract<std::string>(retval);
+    }
+    catch (boost::python::error_already_set)
+    {
+        return nullptr;
+    }
+    return strdup(token.c_str());
+}

--- a/src/x509_scitokens_issuer_client.py
+++ b/src/x509_scitokens_issuer_client.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python
+
+"""
+Utilizing the caller's X509 proxy, act as an OAuth2 client and generate a
+corresponding access token.
+"""
+
+import os
+import sys
+import json
+import urlparse
+
+import requests
+
+class TokenException(Exception):
+    """
+    Base class for token-fetching-related exceptions
+    """
+
+class DiscoverEndpointException(TokenException):
+    """
+    Class for errors related to token issuer endpoint discovery.
+    """
+
+class TokenIssuerException(TokenException):
+    """
+    Class for errors related to token issuance.
+    """
+
+def __configure_authenticated_session(cert=None, key=None):
+    """
+    Generate a new session object for use with requests to the issuer.
+
+    Configures TLS appropriately to work with a GSI environment.
+    """
+    euid = os.geteuid()
+    if euid == 0:
+        default_cert = '/etc/grid-security/hostcert.pem'
+        default_key = '/etc/grid-security/hostkey.pem'
+    else:
+        default_cert = '/tmp/x509up_u%d' % euid
+        default_key = '/tmp/x509up_u%d' % euid
+
+    if not cert:
+        cert = os.environ.get('X509_USER_PROXY', default_cert)
+    if not key:
+        key = os.environ.get('X509_USER_PROXY', default_key)
+
+    session = requests.Session()
+
+    if os.path.exists(cert):
+        session.cert = cert
+    if os.path.exists(key):
+        session.cert = (cert, key)
+
+    return session
+
+
+def __get_token_endpoint(issuer):
+    """
+    From the provided issuer, use OAuth2-style auto-discovery to bootstrap
+    the token endpoint.
+    """
+    if not issuer.endswith("/"):
+        issuer += "/"
+    config_url = urlparse.urljoin(issuer, ".well-known/openid-configuration")
+    response = requests.get(config_url)
+    endpoint_info = json.loads(response.text)
+    if response.status_code != requests.codes.ok:
+        raise DiscoverEndpointException("Failed to access the auto-discovery "
+            "URL (%s) for issuer %s (status=%d): %s" % (config_url, issuer, \
+            response.status, response.text[:2048]))
+    elif 'token_endpoint' not in endpoint_info:
+        raise DiscoverEndpointException("Token endpoint not available for issuer "
+            "%s" % issuer)
+        return False
+    return endpoint_info['token_endpoint']
+
+
+def __generate_token(endpoint, cert=None, key=None):
+    """
+    Call out to the OAuth2 token issuer, using the client credentials
+    grant type, and receive an access token.
+
+    Returns a dictionary based on the server-provided JSON; the following
+    keys are customary:
+
+    - `access_token`: the token itself.
+    - `token_type`: typically `bearer` for generic tokens or possibly `jwt`.
+    - `expires_in`: time, in seconds, until the token expires.
+    """
+    with __configure_authenticated_session(cert=cert, key=key) as session:
+        response = session.post(endpoint, headers={"Accept": "application/json"},
+                                data={"grant_type": "client_credentials"})
+
+    if response.status_code == requests.codes.ok:
+        return json.loads(response.text)
+    else:
+        raise TokenIssuerException("Issuer failed request (status %d): %s" % \
+            (response.status_code, response.text[:2048]))
+
+
+def get_token(issuer, cert=None, key=None):
+    """
+    Given a token issuer, return an access token derived from the provided GSI
+    credentials
+
+    - `issuer`: URL of the token issuer.
+    - `cert`: Filename of the client certificate to use for the TLS connection to
+      the access token endpoint.
+    - `key`: Filename of the client key to use for the TLS connection to the
+      access token endpoint.
+
+    If either `cert` or `key` are None, then the default GSI proxy discovery rules
+    will be utilized.
+
+    This returns a python dictionary describing the token; the dictionary will
+    contain the token in the `access_token` key.
+    """
+    endpoint = __get_token_endpoint(issuer)
+    return __generate_token(endpoint, cert=cert, key=key)
+

--- a/tools/cms-scitoken-init.cpp
+++ b/tools/cms-scitoken-init.cpp
@@ -1,0 +1,80 @@
+/**
+ * Example of using runtime loading to issue a token.
+ */
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+const char *DEFAULT_ISSUER = "https://scitokens.org/cms";
+
+
+int main(int argc, char *argv[])
+{
+    const char *issuer = DEFAULT_ISSUER;
+    if (argc < 2)
+    {
+        fprintf(stderr, "No issuer name specified: using %s.\n", DEFAULT_ISSUER);
+    }
+    else
+    {
+        issuer = argv[1];
+    }
+
+    int (*x509_scitokens_issuer_init_p)(char **);
+    char* (*x509_scitokens_issuer_get_token_p)(const char *, const char *, const char *,
+                                               char**);
+
+    void *handle = dlopen("libX509SciTokensIssuer.so", RTLD_NOW|RTLD_GLOBAL);
+    if (!handle)
+    {
+        fprintf(stderr, "Failed to load the token issuer library: %s\n",
+                dlerror());
+        return 1;
+    }
+    dlerror();
+
+    *(void **)(&x509_scitokens_issuer_init_p) = dlsym(handle, "x509_scitokens_issuer_init");
+    char *error;
+    if ((error = dlerror()) != NULL)
+    {
+        fprintf(stderr, "Failed to load the initializer handle: %s\n", error);
+        dlclose(handle);
+        return 1;
+    } 
+    dlerror();
+
+    *(void **)(&x509_scitokens_issuer_get_token_p) =
+        dlsym(handle, "x509_scitokens_issuer_retrieve");
+    if ((error = dlerror()) != NULL)
+    {
+        fprintf(stderr, "Failed to load the token retrieval handle: %s\n", error);
+        dlclose(handle);
+        return 1;
+    }
+
+    char *err = NULL;
+    if ((*x509_scitokens_issuer_init_p)(&err))
+    {
+        fprintf(stderr, "Failed to initialize the client issuer library: %s\n", err);
+        free(err);
+        dlclose(handle);
+        return 1;
+    }
+
+    char *token = (*x509_scitokens_issuer_get_token_p)(issuer, NULL, NULL, &err);
+    dlclose(handle);
+    if (token)
+    {
+        printf("%s\n", token);
+    }
+    else
+    {
+        fprintf(stderr, "Failed to retrieve token: %s\n", err);
+        free(err);
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This provides a small C library for accessing the `x509-scitokens-issuer` python code.  Intended to help generate tokens from within C or C++ code bases.